### PR TITLE
Handle a null ctxPtr in magicts_update

### DIFF
--- a/src/magicts.cpp
+++ b/src/magicts.cpp
@@ -172,6 +172,11 @@ magicts_initialize(void)
 TouchData
 magicts_update(void *ctxPtr)
 {
+    if(!ctxPtr)
+    {
+        return EMPTY_TOUCH_DATA;
+    }
+
     TouchscreenContext *ctx =  (TouchscreenContext *)ctxPtr;
 
     while(libevdev_has_event_pending(ctx->dev))

--- a/src/magicts.h
+++ b/src/magicts.h
@@ -10,6 +10,13 @@ struct TouchData
 	float y[NUM_TOUCHES];
 };
 
+static const struct TouchData EMPTY_TOUCH_DATA =
+{
+	{  -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1},
+	{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f},
+	{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f}
+};
+
 #ifdef __cplusplus
 extern "C"
 {


### PR DESCRIPTION
Instead of crashing on a null ctxPtr, we can return a TouchData struct with default values which indicate that no touch events are occuring.