### PR TITLE
Ensure the value of slot is initialized correctly

### DIFF
--- a/src/magicts.cpp
+++ b/src/magicts.cpp
@@ -187,6 +187,7 @@ magicts_initialize(void)
         ctx->filedescriptor = get_device(&ctx->dev);
         if(ctx->filedescriptor)
         {
+            ctx->slot = 0;
             get_info(ctx->dev, ABS_MT_POSITION_X, &ctx->minx, &ctx->maxx);
             get_info(ctx->dev, ABS_MT_POSITION_Y, &ctx->miny, &ctx->maxy);
 


### PR DESCRIPTION
Using clang as compiler, the value of slot is initialized in an undetermined fashion, resulting in a possible segfault when the value is not set before trying to set TouchData.